### PR TITLE
ValueError Fix

### DIFF
--- a/Document Similarities/Document_Similarities.ipynb
+++ b/Document Similarities/Document_Similarities.ipynb
@@ -258,7 +258,8 @@
    ],
    "source": [
     "# Every vector is already normalised to have unit L2 norm\n",
-    "np.linalg.norm(tfidf_vectors[0],ord=2)"
+    "p = np.array(tfidf_vectors[0].todense()).reshape(64,)",
+    "p.dot(p)"
    ]
   },
   {

--- a/Document Similarities/Document_Similarities.ipynb
+++ b/Document Similarities/Document_Similarities.ipynb
@@ -258,7 +258,7 @@
    ],
    "source": [
     "# Every vector is already normalised to have unit L2 norm\n",
-    "p = np.array(tfidf_vectors[0].todense()).reshape(64,)",
+    "p = np.array(tfidf_vectors[0].todense()).reshape(64,)\n",
     "p.dot(p)"
    ]
   },


### PR DESCRIPTION
Hey,

Great jop getting all these methods together into one notebook.

I am submitting a fix to calculate the norm of a vector in order to fix a ValueError numpy will throw.

This fix should work despite version of numpy.

Maybe you should update the snippet in Medium if it's there.

Regards,